### PR TITLE
Fix upstream zabbix repo install

### DIFF
--- a/tasks/sles.yml
+++ b/tasks/sles.yml
@@ -17,7 +17,7 @@
         name: "https://repo.zabbix.com/zabbix/{{ ansible_zabbix_agent__version }}/sles/{{  ansible_distribution_major_version }}/x86_64/zabbix-release-{{ ansible_zabbix_agent__release }}.sles{{ ansible_distribution_major_version }}.noarch.rpm"
         state: present
         update_cache: yes
-  when: (ansible_distribution_major_version == 15 and ansible_architecture == "x86_64")
+  when: (ansible_distribution_major_version == "15" and ansible_architecture == "x86_64")
 
 
 - name: Install Zabbix Agent


### PR DESCRIPTION
major_distribution is a string and we were checking it as a int